### PR TITLE
Change property for meta `fb_app` to `fb:app_id`

### DIFF
--- a/wpuseo.php
+++ b/wpuseo.php
@@ -1295,7 +1295,7 @@ class WPUSEO {
         $wputh_fb_app = trim(get_option('wputh_fb_app'));
         if ($this->enable_facebook_metas && !empty($wputh_fb_app)) {
             $metas['fb_app'] = array(
-                'property' => 'fb:app',
+                'property' => 'fb:app_id',
                 'content' => $wputh_fb_app
             );
         }


### PR DESCRIPTION
Hi @Darklg,

I think the `property`for the meta `fb_app` should be changed to `fb:app_id` instead of `fb:app`, as written in the [Facebook documentation](https://developers.facebook.com/docs/sharing/opengraph/using-objects).

